### PR TITLE
simulate-6-months-teamwork: modern DataStack API + new routes

### DIFF
--- a/app/api/v1/activity/route.ts
+++ b/app/api/v1/activity/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  parseOffsetPagination,
+  getRequestId,
+} from "@/lib/api/response";
+
+/**
+ * GET /api/v1/activity
+ * List recent activity across the workspace (runs, deployments, edits).
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const { limit, offset } = parseOffsetPagination(searchParams, { limit: 50 });
+  const requestId = getRequestId(request);
+  const resourceType = searchParams.get("resourceType");
+  const action = searchParams.get("action");
+
+  const activities = [
+    {
+      id: "act-001",
+      resourceType: "job_run",
+      resourceId: "run-1234",
+      action: "completed",
+      userId: "ada@datastack.dev",
+      timestamp: "2024-06-10T09:15:00Z",
+      metadata: { jobId: "1001", duration: 342 },
+    },
+    {
+      id: "act-002",
+      resourceType: "deployment",
+      resourceId: "deploy-003",
+      action: "promoted",
+      userId: "ada@datastack.dev",
+      timestamp: "2024-06-10T08:30:00Z",
+      metadata: { stackId: "stack-001", environment: "PRODUCTION" },
+    },
+    {
+      id: "act-003",
+      resourceType: "query",
+      resourceId: "q-001",
+      action: "executed",
+      userId: "bob@datastack.dev",
+      timestamp: "2024-06-10T08:00:00Z",
+      metadata: { warehouseId: "wh-001", rowCount: 1523 },
+    },
+    {
+      id: "act-004",
+      resourceType: "connection",
+      resourceId: "conn-001",
+      action: "tested",
+      userId: "ada@datastack.dev",
+      timestamp: "2024-06-09T16:45:00Z",
+      metadata: { status: "SUCCESS" },
+    },
+    {
+      id: "act-005",
+      resourceType: "pipeline",
+      resourceId: "pipe-001",
+      action: "started",
+      userId: "ada@datastack.dev",
+      timestamp: "2024-06-09T14:00:00Z",
+      metadata: {},
+    },
+  ];
+
+  let filtered = activities;
+  if (resourceType)
+    filtered = filtered.filter((a) => a.resourceType === resourceType);
+  if (action) filtered = filtered.filter((a) => a.action === action);
+  const totalCount = filtered.length;
+  const paged = filtered.slice(offset, offset + limit);
+
+  return listResponse("activities", paged, totalCount, {
+    limit,
+    offset,
+    requestId,
+  });
+}

--- a/app/api/v1/catalogs/route.ts
+++ b/app/api/v1/catalogs/route.ts
@@ -1,4 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  created,
+  getRequestId,
+} from "@/lib/api/response";
 
 /**
  * @swagger
@@ -35,6 +40,7 @@ import { NextRequest, NextResponse } from "next/server";
  *       201:
  *         description: Created
  */
+
 /**
  * GET /api/v1/catalogs
  * List Unity Catalog catalogs in workspace
@@ -42,10 +48,10 @@ import { NextRequest, NextResponse } from "next/server";
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get("pageSize") ?? "25", 10)));
+  const requestId = getRequestId(request);
 
-  return NextResponse.json({
-    catalogs: [
-      {
+  const catalogs = [
+    {
         name: "main",
         owner: "ada@datastack.dev",
         comment: "Primary production catalog",
@@ -67,9 +73,14 @@ export async function GET(request: NextRequest) {
         updatedAt: "2024-05-20T09:00:00Z",
         createdBy: "bob@datastack.dev",
       },
-    ],
-    totalCount: 2,
+    ];
+
+  const totalCount = catalogs.length;
+  const paged = catalogs.slice(0, pageSize);
+
+  return listResponse("catalogs", paged, totalCount, {
     pageSize,
+    requestId,
   });
 }
 
@@ -78,13 +89,14 @@ export async function GET(request: NextRequest) {
  * Create a new catalog
  */
 export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
   const body = (await request.json()) as {
     name: string;
     comment?: string;
     properties?: Record<string, string>;
     isolation?: string;
   };
-  return NextResponse.json(
+  return created(
     {
       name: body.name,
       owner: "api",
@@ -96,6 +108,6 @@ export async function POST(request: NextRequest) {
       updatedAt: new Date().toISOString(),
       createdBy: "api",
     },
-    { status: 201 }
+    { requestId }
   );
 }

--- a/app/api/v1/clusters/route.ts
+++ b/app/api/v1/clusters/route.ts
@@ -1,5 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { isPreviewEnabled } from "@/lib/api/preview";
+import {
+  listResponse,
+  created,
+  parsePagePagination,
+  getRequestId,
+} from "@/lib/api/response";
 
 /**
  * @swagger
@@ -104,16 +110,15 @@ import { isPreviewEnabled } from "@/lib/api/preview";
  */
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
-  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
-  const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get("pageSize") ?? "25", 10)));
+  const { page, pageSize } = parsePagePagination(searchParams, { pageSize: 25 });
+  const requestId = getRequestId(request);
   const state = searchParams.get("state");
   const sortBy = searchParams.get("sortBy") ?? "createdAt";
   const sortOrder = searchParams.get("sortOrder") ?? "desc";
 
-  return NextResponse.json({
-    clusters: [
-      {
-        id: "cluster-001",
+  const clusters = [
+    {
+      id: "cluster-001",
         name: "Analytics Cluster",
         clusterSize: "Medium",
         region: "us-east-1",
@@ -147,10 +152,17 @@ export async function GET(request: NextRequest) {
         createdAt: "2024-03-15T14:00:00Z",
         lastActivityAt: "2024-06-10T07:30:00Z",
       },
-    ],
-    totalCount: 2,
+    ];
+
+  let filtered = state ? clusters.filter((c) => c.state === state) : clusters;
+  const totalCount = filtered.length;
+  const start = (page - 1) * pageSize;
+  const paged = filtered.slice(start, start + pageSize);
+
+  return listResponse("clusters", paged, totalCount, {
     page,
     pageSize,
+    requestId,
   });
 }
 
@@ -178,6 +190,7 @@ export async function POST(request: NextRequest) {
     tags?: Record<string, string>;
   };
 
+  const requestId = getRequestId(request);
   const response: Record<string, unknown> = {
     id: "cluster-new",
     name: body.name,
@@ -206,5 +219,5 @@ export async function POST(request: NextRequest) {
     createdBy: "api",
   };
 
-  return NextResponse.json(response, { status: 201 });
+  return created(response as Record<string, unknown>, { requestId });
 }

--- a/app/api/v1/connections/bulk-test/route.ts
+++ b/app/api/v1/connections/bulk-test/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from "next/server";
+import { ok, getRequestId } from "@/lib/api/response";
+
+/**
+ * POST /api/v1/connections/bulk-test
+ * Test connectivity for multiple connections in parallel.
+ */
+export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
+  const body = (await request.json()) as { connectionIds: string[] };
+  const connectionIds = body.connectionIds ?? [];
+
+  const results = connectionIds.map((id) => ({
+    connectionId: id,
+    status: "SUCCESS" as const,
+    latencyMs: Math.floor(Math.random() * 50) + 10,
+    message: "Connection verified",
+  }));
+
+  return ok(
+    {
+      results,
+      summary: {
+        total: results.length,
+        successful: results.length,
+        failed: 0,
+      },
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/connections/route.ts
+++ b/app/api/v1/connections/route.ts
@@ -1,4 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  created,
+  parsePagePagination,
+  getRequestId,
+} from "@/lib/api/response";
 
 /**
  * @swagger
@@ -71,12 +77,13 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
-  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
-  const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get("pageSize") ?? "25", 10)));
+  const { page, pageSize } = parsePagePagination(searchParams, { pageSize: 25 });
+  const requestId = getRequestId(request);
+  const type = searchParams.get("type");
+  const status = searchParams.get("status");
 
-  return NextResponse.json({
-    connections: [
-      {
+  const connections = [
+    {
         id: "conn-001",
         name: "Production S3",
         type: "S3",
@@ -123,14 +130,24 @@ export async function GET(request: NextRequest) {
         lastTestStatus: "SUCCESS",
         lastHealthCheckAt: "2024-06-10T08:01:00Z",
       },
-    ],
-    totalCount: 2,
+    ];
+
+  let filtered = connections;
+  if (type) filtered = filtered.filter((c) => c.type === type);
+  if (status) filtered = filtered.filter((c) => c.status === status);
+  const totalCount = filtered.length;
+  const start = (page - 1) * pageSize;
+  const paged = filtered.slice(start, start + pageSize);
+
+  return listResponse("connections", paged, totalCount, {
     page,
     pageSize,
+    requestId,
   });
 }
 
 export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
   const body = (await request.json()) as {
     name: string;
     type: string;
@@ -143,7 +160,7 @@ export async function POST(request: NextRequest) {
     properties?: Record<string, unknown>;
     tags?: Record<string, string>;
   };
-  return NextResponse.json(
+  return created(
     {
       id: "conn-new",
       name: body.name,
@@ -163,6 +180,6 @@ export async function POST(request: NextRequest) {
       lastTestedAt: null,
       lastTestStatus: null,
     },
-    { status: 201 }
+    { requestId }
   );
 }

--- a/app/api/v1/dashboards/[dashboardId]/route.ts
+++ b/app/api/v1/dashboards/[dashboardId]/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest } from "next/server";
+import { ok, noContent, getRequestId } from "@/lib/api/response";
+
+/**
+ * GET /api/v1/dashboards/{dashboardId}
+ * Get dashboard with widget configuration.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ dashboardId: string }> }
+) {
+  const { dashboardId } = await params;
+  const requestId = getRequestId(request);
+
+  return ok(
+    {
+      id: dashboardId,
+      name: "Platform Overview",
+      workspaceId: "ws-001",
+      widgets: [
+        { id: "w1", type: "job_runs", config: {}, position: { x: 0, y: 0, w: 6, h: 3 } },
+        { id: "w2", type: "cluster_utilization", config: {}, position: { x: 6, y: 0, w: 6, h: 3 } },
+        { id: "w3", type: "query_volume", config: {}, position: { x: 0, y: 3, w: 12, h: 2 } },
+      ],
+      createdAt: "2024-04-01T10:00:00Z",
+      updatedAt: "2024-06-01T12:00:00Z",
+    },
+    { requestId }
+  );
+}
+
+/**
+ * PATCH /api/v1/dashboards/{dashboardId}
+ * Update dashboard name or widget layout.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ dashboardId: string }> }
+) {
+  const { dashboardId } = await params;
+  const requestId = getRequestId(request);
+  const body = (await request.json()) as Record<string, unknown>;
+
+  return ok(
+    {
+      id: dashboardId,
+      ...body,
+      updatedAt: new Date().toISOString(),
+    },
+    { requestId }
+  );
+}
+
+/**
+ * DELETE /api/v1/dashboards/{dashboardId}
+ */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ dashboardId: string }> }
+) {
+  await params;
+  return noContent({ requestId: getRequestId(_request) });
+}

--- a/app/api/v1/dashboards/route.ts
+++ b/app/api/v1/dashboards/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  created,
+  parsePagePagination,
+  getRequestId,
+} from "@/lib/api/response";
+
+/**
+ * GET /api/v1/dashboards
+ * List saved dashboards (widget layouts).
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const { page, pageSize } = parsePagePagination(searchParams, { pageSize: 25 });
+  const requestId = getRequestId(request);
+
+  const dashboards = [
+    {
+      id: "dash-001",
+      name: "Platform Overview",
+      workspaceId: "ws-001",
+      widgetCount: 6,
+      createdAt: "2024-04-01T10:00:00Z",
+      updatedAt: "2024-06-01T12:00:00Z",
+      createdBy: "ada@datastack.dev",
+    },
+    {
+      id: "dash-002",
+      name: "ETL Health",
+      workspaceId: "ws-001",
+      widgetCount: 4,
+      createdAt: "2024-05-15T14:00:00Z",
+      updatedAt: "2024-05-20T09:00:00Z",
+      createdBy: "bob@datastack.dev",
+    },
+  ];
+
+  const totalCount = dashboards.length;
+  const start = (page - 1) * pageSize;
+  const paged = dashboards.slice(start, start + pageSize);
+
+  return listResponse("dashboards", paged, totalCount, {
+    page,
+    pageSize,
+    requestId,
+  });
+}
+
+/**
+ * POST /api/v1/dashboards
+ * Create a new dashboard.
+ */
+export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
+  const body = (await request.json()) as { name: string; workspaceId: string };
+
+  return created(
+    {
+      id: "dash-new",
+      name: body.name,
+      workspaceId: body.workspaceId,
+      widgetCount: 0,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      createdBy: "api",
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/deployments/route.ts
+++ b/app/api/v1/deployments/route.ts
@@ -1,4 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  parsePagePagination,
+  getRequestId,
+} from "@/lib/api/response";
 
 /**
  * @swagger
@@ -16,12 +21,14 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
-  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
-  const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get("pageSize") ?? "25", 10)));
+  const { page, pageSize } = parsePagePagination(searchParams, { pageSize: 25 });
+  const requestId = getRequestId(request);
+  const stackId = searchParams.get("stackId");
+  const environment = searchParams.get("environment");
+  const status = searchParams.get("status");
 
-  return NextResponse.json({
-    deployments: [
-      {
+  const deployments = [
+    {
         id: "deploy-003",
         stackId: "stack-001",
         stackName: "Analytics Platform",
@@ -63,9 +70,19 @@ export async function GET(request: NextRequest) {
         startedBy: "bob@datastack.dev",
         promotedFrom: null,
       },
-    ],
-    totalCount: 3,
+    ];
+
+  let filtered = deployments;
+  if (stackId) filtered = filtered.filter((d) => d.stackId === stackId);
+  if (environment) filtered = filtered.filter((d) => d.environment === environment);
+  if (status) filtered = filtered.filter((d) => d.status === status);
+  const totalCount = filtered.length;
+  const start = (page - 1) * pageSize;
+  const paged = filtered.slice(start, start + pageSize);
+
+  return listResponse("deployments", paged, totalCount, {
     page,
     pageSize,
+    requestId,
   });
 }

--- a/app/api/v1/favorites/[resourceType]/[resourceId]/route.ts
+++ b/app/api/v1/favorites/[resourceType]/[resourceId]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { noContent, getRequestId } from "@/lib/api/response";
+
+/**
+ * DELETE /api/v1/favorites/{resourceType}/{resourceId}
+ * Remove a resource from favorites.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ resourceType: string; resourceId: string }> }
+) {
+  const { resourceType, resourceId } = await params;
+  return noContent({ requestId: getRequestId(request) });
+}

--- a/app/api/v1/favorites/route.ts
+++ b/app/api/v1/favorites/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  created,
+  parsePagePagination,
+  getRequestId,
+} from "@/lib/api/response";
+
+/**
+ * GET /api/v1/favorites
+ * List the caller's favorited resources (queries, clusters, pipelines, etc).
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const { page, pageSize } = parsePagePagination(searchParams, { pageSize: 25 });
+  const requestId = getRequestId(request);
+  const resourceType = searchParams.get("resourceType");
+
+  const favorites = [
+    {
+      id: "fav-001",
+      resourceType: "query",
+      resourceId: "q-001",
+      resourceName: "Daily Active Users",
+      addedAt: "2024-05-15T10:00:00Z",
+    },
+    {
+      id: "fav-002",
+      resourceType: "pipeline",
+      resourceId: "pipe-001",
+      resourceName: "Bronze Ingestion",
+      addedAt: "2024-05-20T14:30:00Z",
+    },
+    {
+      id: "fav-003",
+      resourceType: "cluster",
+      resourceId: "cluster-001",
+      resourceName: "Analytics Cluster",
+      addedAt: "2024-06-01T09:00:00Z",
+    },
+  ];
+
+  const filtered = resourceType
+    ? favorites.filter((f) => f.resourceType === resourceType)
+    : favorites;
+  const totalCount = filtered.length;
+  const start = (page - 1) * pageSize;
+  const paged = filtered.slice(start, start + pageSize);
+
+  return listResponse("favorites", paged, totalCount, {
+    page,
+    pageSize,
+    requestId,
+  });
+}
+
+/**
+ * POST /api/v1/favorites
+ * Add a resource to favorites.
+ */
+export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
+  const body = (await request.json()) as {
+    resourceType: string;
+    resourceId: string;
+  };
+
+  return created(
+    {
+      id: "fav-new",
+      resourceType: body.resourceType,
+      resourceId: body.resourceId,
+      addedAt: new Date().toISOString(),
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/health/route.ts
+++ b/app/api/v1/health/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { getRequestId } from "@/lib/api/response";
+
+/**
+ * GET /api/v1/health
+ * Liveness/readiness check for load balancers and orchestrators.
+ * Returns 200 when the API is accepting requests.
+ */
+export async function GET(request: Request) {
+  const requestId = getRequestId(request);
+  return NextResponse.json(
+    {
+      status: "ok",
+      version: "1.0.0",
+      timestamp: new Date().toISOString(),
+      requestId,
+    },
+    {
+      headers: {
+        "x-request-id": requestId,
+      },
+    }
+  );
+}

--- a/app/api/v1/jobs/bulk-pause/route.ts
+++ b/app/api/v1/jobs/bulk-pause/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+import { ok, getRequestId } from "@/lib/api/response";
+
+/**
+ * POST /api/v1/jobs/bulk-pause
+ * Pause multiple jobs in a single request.
+ */
+export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
+  const body = (await request.json()) as { jobIds: string[] };
+  const jobIds = body.jobIds ?? [];
+
+  return ok(
+    {
+      paused: jobIds,
+      failed: [] as string[],
+      message: `Paused ${jobIds.length} job(s)`,
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/jobs/bulk-resume/route.ts
+++ b/app/api/v1/jobs/bulk-resume/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+import { ok, getRequestId } from "@/lib/api/response";
+
+/**
+ * POST /api/v1/jobs/bulk-resume
+ * Resume multiple paused jobs in a single request.
+ */
+export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
+  const body = (await request.json()) as { jobIds: string[] };
+  const jobIds = body.jobIds ?? [];
+
+  return ok(
+    {
+      resumed: jobIds,
+      failed: [] as string[],
+      message: `Resumed ${jobIds.length} job(s)`,
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/jobs/route.ts
+++ b/app/api/v1/jobs/route.ts
@@ -1,4 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  created,
+  parseOffsetPagination,
+  getRequestId,
+} from "@/lib/api/response";
 
 /**
  * @swagger
@@ -108,12 +114,14 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
-  const limit = Math.min(100, Math.max(1, parseInt(searchParams.get("limit") ?? "25", 10)));
-  const offset = Math.max(0, parseInt(searchParams.get("offset") ?? "0", 10));
+  const { limit, offset } = parseOffsetPagination(searchParams, { limit: 25 });
+  const requestId = getRequestId(request);
+  const state = searchParams.get("state");
+  const ownerId = searchParams.get("ownerId");
+  const tagFilter = searchParams.get("tagFilter");
 
-  return NextResponse.json({
-    jobs: [
-      {
+  const jobs = [
+    {
         jobId: 1001,
         name: "Daily ETL",
         description: "Ingest and transform raw events",
@@ -167,12 +175,24 @@ export async function GET(request: NextRequest) {
         lastRunStatus: "SUCCESS",
         nextRunAt: "2024-06-10T09:00:00Z",
       },
-    ],
-    totalCount: 2,
+    ];
+
+  let filtered = jobs;
+  if (state) filtered = filtered.filter((j) => j.state === state);
+  if (ownerId) filtered = filtered.filter((j) => j.createdBy === ownerId);
+  if (tagFilter) filtered = filtered.filter((j) => Object.values(j.tags ?? {}).some((v) => String(v).includes(tagFilter)));
+  const totalCount = filtered.length;
+  const paged = filtered.slice(offset, offset + limit);
+
+  return listResponse("jobs", paged, totalCount, {
+    limit,
+    offset,
+    requestId,
   });
 }
 
 export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
   const body = (await request.json()) as {
     name: string;
     description?: string;
@@ -186,7 +206,7 @@ export async function POST(request: NextRequest) {
     tags?: Record<string, string>;
   };
 
-  return NextResponse.json(
+  return created(
     {
       jobId: 2001,
       name: body.name,
@@ -203,6 +223,6 @@ export async function POST(request: NextRequest) {
       createdAt: new Date().toISOString(),
       createdBy: "api",
     },
-    { status: 201 }
+    { requestId }
   );
 }

--- a/app/api/v1/limits/route.ts
+++ b/app/api/v1/limits/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from "next/server";
+import { ok, getRequestId } from "@/lib/api/response";
+
+/**
+ * GET /api/v1/limits
+ * Get account and workspace limits (quotas).
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const requestId = getRequestId(request);
+  const workspaceId = searchParams.get("workspaceId");
+
+  return ok(
+    {
+      workspaceId: workspaceId ?? "ws-001",
+      limits: {
+        clusters: { max: 50, current: 12 },
+        jobs: { max: 200, current: 45 },
+        pipelines: { max: 100, current: 23 },
+        sqlWarehouses: { max: 30, current: 8 },
+        connections: { max: 100, current: 15 },
+        webhooks: { max: 50, current: 5 },
+        apiKeys: { max: 20, current: 3 },
+        users: { max: 100, current: 24 },
+      },
+      tier: "enterprise",
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/me/preferences/route.ts
+++ b/app/api/v1/me/preferences/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from "next/server";
+import { ok, getRequestId } from "@/lib/api/response";
+
+/**
+ * GET /api/v1/me/preferences
+ * Get the current user's UI and notification preferences.
+ */
+export async function GET(request: NextRequest) {
+  const requestId = getRequestId(request);
+
+  return ok(
+    {
+      theme: "system",
+      defaultPageSize: 25,
+      timezone: "America/Los_Angeles",
+      dateFormat: "YYYY-MM-DD",
+      notifications: {
+        emailDigest: "weekly",
+        slackEnabled: true,
+        jobAlerts: true,
+        deploymentAlerts: true,
+      },
+    },
+    { requestId }
+  );
+}
+
+/**
+ * PATCH /api/v1/me/preferences
+ * Update the current user's preferences.
+ */
+export async function PATCH(request: NextRequest) {
+  const requestId = getRequestId(request);
+  const body = (await request.json()) as Record<string, unknown>;
+
+  return ok(
+    {
+      theme: (body.theme as string) ?? "system",
+      defaultPageSize: (body.defaultPageSize as number) ?? 25,
+      timezone: (body.timezone as string) ?? "America/Los_Angeles",
+      dateFormat: (body.dateFormat as string) ?? "YYYY-MM-DD",
+      notifications: { ...(body.notifications as object) },
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/me/recent/route.ts
+++ b/app/api/v1/me/recent/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from "next/server";
+import { ok, getRequestId } from "@/lib/api/response";
+
+/**
+ * GET /api/v1/me/recent
+ * Get resources the current user recently viewed or edited.
+ */
+export async function GET(request: NextRequest) {
+  const requestId = getRequestId(request);
+
+  return ok(
+    {
+      queries: [
+        { id: "q-001", name: "Daily Active Users", lastViewedAt: "2024-06-10T09:00:00Z" },
+      ],
+      pipelines: [
+        { id: "pipe-001", name: "Bronze Ingestion", lastViewedAt: "2024-06-09T16:00:00Z" },
+      ],
+      clusters: [
+        { id: "cluster-001", name: "Analytics Cluster", lastViewedAt: "2024-06-08T14:00:00Z" },
+      ],
+      stacks: [
+        { id: "stack-001", name: "Analytics Platform", lastViewedAt: "2024-06-10T08:30:00Z" },
+      ],
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/me/route.ts
+++ b/app/api/v1/me/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from "next/server";
+import { ok, getRequestId } from "@/lib/api/response";
+
+/**
+ * GET /api/v1/me
+ * Get the current authenticated user's profile.
+ */
+export async function GET(request: NextRequest) {
+  const requestId = getRequestId(request);
+
+  return ok(
+    {
+      id: "u1",
+      displayName: "Ada Lovelace",
+      email: "ada@datastack.dev",
+      avatarUrl: "https://api.datastack.dev/avatars/ada.png",
+      role: "admin",
+      status: "active",
+      department: "Engineering",
+      teamIds: ["team-eng", "team-platform"],
+      permissions: ["clusters:write", "jobs:write", "pipelines:write", "admin:users"],
+      mfaEnabled: true,
+      createdAt: "2024-01-15T10:00:00Z",
+      lastLoginAt: "2024-06-10T08:00:00Z",
+      preferredWorkspaceId: "ws-001",
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/pipelines/[pipelineId]/clone/route.ts
+++ b/app/api/v1/pipelines/[pipelineId]/clone/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { created, getRequestId } from "@/lib/api/response";
+
+/**
+ * POST /api/v1/pipelines/{pipelineId}/clone
+ * Clone a pipeline with a new name (copy configuration).
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ pipelineId: string }> }
+) {
+  const { pipelineId } = await params;
+  const requestId = getRequestId(request);
+  const body = (await request.json()) as { name?: string };
+
+  return created(
+    {
+      id: "pipe-clone",
+      sourcePipelineId: pipelineId,
+      name: body.name ?? `Clone of ${pipelineId}`,
+      state: "IDLE",
+      workspaceId: "ws-001",
+      createdAt: new Date().toISOString(),
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/pipelines/route.ts
+++ b/app/api/v1/pipelines/route.ts
@@ -1,5 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { isPreviewEnabled } from "@/lib/api/preview";
+import {
+  listResponse,
+  created,
+  parsePagePagination,
+  getRequestId,
+} from "@/lib/api/response";
 
 /**
  * @swagger
@@ -115,10 +121,12 @@ import { isPreviewEnabled } from "@/lib/api/preview";
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get("pageSize") ?? "25", 10)));
+  const requestId = getRequestId(request);
+  const state = searchParams.get("state");
+  const edition = searchParams.get("edition");
 
-  return NextResponse.json({
-    pipelines: [
-      {
+  const pipelines = [
+    {
         id: "pipe-001",
         name: "Bronze Ingestion",
         workspaceId: "ws-001",
@@ -174,12 +182,22 @@ export async function GET(request: NextRequest) {
         lastRunAt: null,
         lastRunStatus: null,
       },
-    ],
-    totalCount: 2,
+    ];
+
+  let filtered = pipelines;
+  if (state) filtered = filtered.filter((p) => p.state === state);
+  if (edition) filtered = filtered.filter((p) => p.edition === edition);
+  const totalCount = filtered.length;
+  const paged = filtered.slice(0, pageSize);
+
+  return listResponse("pipelines", paged, totalCount, {
+    pageSize,
+    requestId,
   });
 }
 
 export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
   const body = (await request.json()) as {
     name: string;
     workspaceId: string;
@@ -196,7 +214,7 @@ export async function POST(request: NextRequest) {
     clusterConfig?: Record<string, unknown>;
   };
 
-  return NextResponse.json(
+  return created(
     {
       id: "pipe-new",
       name: body.name,
@@ -216,6 +234,6 @@ export async function POST(request: NextRequest) {
       createdAt: new Date().toISOString(),
       createdBy: "api",
     },
-    { status: 201 }
+    { requestId }
   );
 }

--- a/app/api/v1/queries/[queryId]/clone/route.ts
+++ b/app/api/v1/queries/[queryId]/clone/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { created, getRequestId } from "@/lib/api/response";
+
+/**
+ * POST /api/v1/queries/{queryId}/clone
+ * Clone a saved query with a new name.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ queryId: string }> }
+) {
+  const { queryId } = await params;
+  const requestId = getRequestId(request);
+  const body = (await request.json()) as { name?: string };
+
+  return created(
+    {
+      id: "q-clone",
+      sourceQueryId: queryId,
+      name: body.name ?? `Copy of query`,
+      warehouseId: "wh-001",
+      createdAt: new Date().toISOString(),
+      createdBy: "api",
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/queries/route.ts
+++ b/app/api/v1/queries/route.ts
@@ -1,4 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  created,
+  parseOffsetPagination,
+  getRequestId,
+} from "@/lib/api/response";
 
 /**
  * @swagger
@@ -74,11 +80,14 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
-  const limit = Math.min(100, Math.max(1, parseInt(searchParams.get("limit") ?? "25", 10)));
+  const { limit, offset } = parseOffsetPagination(searchParams, { limit: 25 });
+  const requestId = getRequestId(request);
+  const warehouseId = searchParams.get("warehouseId");
+  const ownerId = searchParams.get("ownerId");
+  const tag = searchParams.get("tag");
 
-  return NextResponse.json({
-    queries: [
-      {
+  const queries = [
+    {
         id: "q-001",
         name: "Daily Active Users",
         description: "Count DAU by platform",
@@ -96,12 +105,24 @@ export async function GET(request: NextRequest) {
         lastExecutedAt: "2024-06-10T09:00:00Z",
         executionCount: 180,
       },
-    ],
-    totalCount: 1,
+    ];
+
+  let filtered = queries;
+  if (warehouseId) filtered = filtered.filter((q) => q.warehouseId === warehouseId);
+  if (ownerId) filtered = filtered.filter((q) => q.createdBy === ownerId);
+  if (tag) filtered = filtered.filter((q) => q.tags?.includes(tag));
+  const totalCount = filtered.length;
+  const paged = filtered.slice(offset, offset + limit);
+
+  return listResponse("queries", paged, totalCount, {
+    limit,
+    offset,
+    requestId,
   });
 }
 
 export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
   const body = (await request.json()) as {
     name: string;
     description?: string;
@@ -114,7 +135,7 @@ export async function POST(request: NextRequest) {
     parameters?: { name: string; type: string; defaultValue: string }[];
     tags?: string[];
   };
-  return NextResponse.json(
+  return created(
     {
       id: "q-new",
       name: body.name,
@@ -131,6 +152,6 @@ export async function POST(request: NextRequest) {
       updatedAt: new Date().toISOString(),
       createdBy: "api",
     },
-    { status: 201 }
+    { requestId }
   );
 }

--- a/app/api/v1/sql/warehouses/route.ts
+++ b/app/api/v1/sql/warehouses/route.ts
@@ -1,4 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  parsePagePagination,
+  getRequestId,
+} from "@/lib/api/response";
 
 /**
  * @swagger
@@ -15,12 +20,12 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
-  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
-  const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get("pageSize") ?? "25", 10)));
+  const { page, pageSize } = parsePagePagination(searchParams, { pageSize: 25 });
+  const requestId = getRequestId(request);
+  const state = searchParams.get("state");
 
-  return NextResponse.json({
-    warehouses: [
-      {
+  const warehouses = [
+    {
         id: "wh-001",
         name: "BI Warehouse",
         clusterSize: "Small",
@@ -40,7 +45,17 @@ export async function GET(request: NextRequest) {
           "Driver={DataStack};Server=wh-002.us-west-2.datastack.cloud;Port=443",
         createdAt: "2024-02-05T14:00:00Z",
       },
-    ],
-    totalCount: 2,
+    ];
+
+  let filtered = warehouses;
+  if (state) filtered = filtered.filter((w) => w.state === state);
+  const totalCount = filtered.length;
+  const start = (page - 1) * pageSize;
+  const paged = filtered.slice(start, start + pageSize);
+
+  return listResponse("warehouses", paged, totalCount, {
+    page,
+    pageSize,
+    requestId,
   });
 }

--- a/app/api/v1/stacks/[stackId]/route.ts
+++ b/app/api/v1/stacks/[stackId]/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { ok, noContent, getRequestId } from "@/lib/api/response";
 
 /**
  * @swagger
@@ -92,11 +93,12 @@ import { NextRequest, NextResponse } from "next/server";
  *         description: No content
  */
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ stackId: string }> }
 ) {
   const { stackId } = await params;
-  return NextResponse.json({
+  const requestId = getRequestId(request);
+  return ok({
     id: stackId,
     name: "Analytics Platform",
     description: "End-to-end analytics pipeline",
@@ -124,7 +126,7 @@ export async function GET(
       { version: "2.4.1", deployedAt: "2024-06-05T14:30:00Z", deployedBy: "api" },
       { version: "2.4.0", deployedAt: "2024-05-20T10:00:00Z", deployedBy: "ada@datastack.dev" },
     ],
-  });
+  }, { requestId });
 }
 
 export async function PATCH(
@@ -133,17 +135,21 @@ export async function PATCH(
 ) {
   const { stackId } = await params;
   const body = (await request.json()) as Record<string, unknown>;
-  return NextResponse.json({
-    id: stackId,
-    ...body,
-    updatedAt: new Date().toISOString(),
-  });
+  const requestId = getRequestId(request);
+  return ok(
+    {
+      id: stackId,
+      ...body,
+      updatedAt: new Date().toISOString(),
+    },
+    { requestId }
+  );
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ stackId: string }> }
 ) {
   await params;
-  return new NextResponse(null, { status: 204 });
+  return noContent({ requestId: getRequestId(request) });
 }

--- a/app/api/v1/stacks/bulk-validate/route.ts
+++ b/app/api/v1/stacks/bulk-validate/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest } from "next/server";
+import { ok, getRequestId } from "@/lib/api/response";
+
+/**
+ * POST /api/v1/stacks/bulk-validate
+ * Validate multiple stacks in parallel.
+ */
+export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
+  const body = (await request.json()) as { stackIds: string[] };
+  const stackIds = body.stackIds ?? [];
+
+  const results = stackIds.map((id) => ({
+    stackId: id,
+    valid: true,
+    checks: [
+      { name: "layers", status: "PASSED" },
+      { name: "connections", status: "PASSED" },
+      { name: "dependencies", status: "PASSED" },
+    ],
+  }));
+
+  return ok(
+    {
+      results,
+      summary: {
+        total: results.length,
+        passed: results.length,
+        failed: 0,
+      },
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/stacks/route.ts
+++ b/app/api/v1/stacks/route.ts
@@ -1,4 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  created,
+  parsePagePagination,
+  getRequestId,
+} from "@/lib/api/response";
 
 /**
  * @swagger
@@ -99,36 +105,52 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
+  const { page, pageSize } = parsePagePagination(searchParams, { pageSize: 25 });
+  const requestId = getRequestId(request);
 
-  return NextResponse.json({
-    stacks: [
-      {
-        id: "stack-001",
-        name: "Analytics Platform",
-        description: "End-to-end analytics pipeline",
-        workspaceId: "ws-001",
-        environment: "production",
-        version: "2.4.1",
-        lockState: "UNLOCKED",
-        lockedBy: null,
-        lockedAt: null,
-        layers: [
-          { name: "Storage", resourceType: "catalog", resourceId: "cat-001", order: 1, dependsOn: [] },
-          { name: "Ingestion", resourceType: "pipeline", resourceId: "pipe-001", order: 2, dependsOn: ["Storage"] },
-          { name: "Transform", resourceType: "job", resourceId: "job-1001", order: 3, dependsOn: ["Ingestion"] },
-        ],
-        connections: ["conn-001", "conn-002"],
-        tags: { team: "platform", tier: "critical" },
-        autoDeployOnPush: true,
-        gitRepository: "https://github.com/acme/analytics-stack",
-        gitBranch: "main",
-        createdAt: "2024-02-01T10:00:00Z",
-        updatedAt: "2024-06-05T14:00:00Z",
-        lastDeployedAt: "2024-06-05T14:30:00Z",
-        lastDeployStatus: "SUCCESS",
-      },
-    ],
-    totalCount: 1,
+  const environment = searchParams.get("environment");
+  const lockState = searchParams.get("lockState");
+
+  const stacks = [
+    {
+      id: "stack-001",
+      name: "Analytics Platform",
+      description: "End-to-end analytics pipeline",
+      workspaceId: "ws-001",
+      environment: "production",
+      version: "2.4.1",
+      lockState: "UNLOCKED",
+      lockedBy: null,
+      lockedAt: null,
+      layers: [
+        { name: "Storage", resourceType: "catalog", resourceId: "cat-001", order: 1, dependsOn: [] },
+        { name: "Ingestion", resourceType: "pipeline", resourceId: "pipe-001", order: 2, dependsOn: ["Storage"] },
+        { name: "Transform", resourceType: "job", resourceId: "job-1001", order: 3, dependsOn: ["Ingestion"] },
+      ],
+      connections: ["conn-001", "conn-002"],
+      tags: { team: "platform", tier: "critical" },
+      autoDeployOnPush: true,
+      gitRepository: "https://github.com/acme/analytics-stack",
+      gitBranch: "main",
+      createdAt: "2024-02-01T10:00:00Z",
+      updatedAt: "2024-06-05T14:00:00Z",
+      lastDeployedAt: "2024-06-05T14:30:00Z",
+      lastDeployStatus: "SUCCESS",
+    },
+  ];
+
+  let filtered = stacks;
+  if (environment) filtered = filtered.filter((s) => s.environment === environment);
+  if (lockState) filtered = filtered.filter((s) => s.lockState === lockState);
+
+  const totalCount = filtered.length;
+  const start = (page - 1) * pageSize;
+  const paged = filtered.slice(start, start + pageSize);
+
+  return listResponse("stacks", paged, totalCount, {
+    page,
+    pageSize,
+    requestId,
   });
 }
 
@@ -146,7 +168,8 @@ export async function POST(request: NextRequest) {
     gitRepository?: string;
     gitBranch?: string;
   };
-  return NextResponse.json(
+  const requestId = getRequestId(request);
+  return created(
     {
       id: "stack-new",
       name: body.name,
@@ -166,6 +189,6 @@ export async function POST(request: NextRequest) {
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     },
-    { status: 201 }
+    { requestId }
   );
 }

--- a/app/api/v1/tags/route.ts
+++ b/app/api/v1/tags/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  created,
+  parsePagePagination,
+  getRequestId,
+} from "@/lib/api/response";
+
+/**
+ * GET /api/v1/tags
+ * List tags used across the workspace (tag taxonomy).
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const { page, pageSize } = parsePagePagination(searchParams, { pageSize: 50 });
+  const requestId = getRequestId(request);
+  const prefix = searchParams.get("prefix");
+
+  const tags = [
+    { key: "team", value: "platform", resourceCount: 12 },
+    { key: "team", value: "analytics", resourceCount: 8 },
+    { key: "env", value: "production", resourceCount: 15 },
+    { key: "env", value: "staging", resourceCount: 6 },
+    { key: "tier", value: "critical", resourceCount: 5 },
+    { key: "project", value: "revenue-analytics", resourceCount: 3 },
+  ];
+
+  const filtered = prefix
+    ? tags.filter((t) => t.key.startsWith(prefix) || t.value.startsWith(prefix))
+    : tags;
+  const totalCount = filtered.length;
+  const start = (page - 1) * pageSize;
+  const paged = filtered.slice(start, start + pageSize);
+
+  return listResponse("tags", paged, totalCount, {
+    page,
+    pageSize,
+    requestId,
+  });
+}
+
+/**
+ * POST /api/v1/tags
+ * Create or register a tag key-value (for taxonomy).
+ */
+export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
+  const body = (await request.json()) as { key: string; value: string };
+
+  return created(
+    {
+      key: body.key,
+      value: body.value,
+      resourceCount: 0,
+      createdAt: new Date().toISOString(),
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/tags/suggest/route.ts
+++ b/app/api/v1/tags/suggest/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest } from "next/server";
+import { ok, getRequestId } from "@/lib/api/response";
+
+/**
+ * GET /api/v1/tags/suggest
+ * Suggest tag keys/values based on partial input (autocomplete).
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const requestId = getRequestId(request);
+  const q = searchParams.get("q") ?? "";
+
+  const suggestions = [
+    { key: "team", value: "platform", match: "team:platform" },
+    { key: "team", value: "analytics", match: "team:analytics" },
+    { key: "env", value: "production", match: "env:production" },
+  ].filter((s) => s.match.toLowerCase().includes(q.toLowerCase()));
+
+  return ok(
+    {
+      suggestions: suggestions.slice(0, 10),
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/templates/[templateId]/instantiate/route.ts
+++ b/app/api/v1/templates/[templateId]/instantiate/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from "next/server";
+import { created, getRequestId } from "@/lib/api/response";
+
+/**
+ * POST /api/v1/templates/{templateId}/instantiate
+ * Create a stack or pipeline from a template with variable substitution.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ templateId: string }> }
+) {
+  const { templateId } = await params;
+  const requestId = getRequestId(request);
+  const body = (await request.json()) as {
+    workspaceId: string;
+    name: string;
+    variables?: Record<string, string>;
+  };
+
+  return created(
+    {
+      id: "stack-from-template",
+      templateId,
+      name: body.name ?? "Untitled Stack",
+      workspaceId: body.workspaceId,
+      status: "PROVISIONING",
+      createdAt: new Date().toISOString(),
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/templates/[templateId]/route.ts
+++ b/app/api/v1/templates/[templateId]/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from "next/server";
+import { ok, getRequestId } from "@/lib/api/response";
+
+/**
+ * GET /api/v1/templates/{templateId}
+ * Get template details and configuration.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ templateId: string }> }
+) {
+  const { templateId } = await params;
+  const requestId = getRequestId(request);
+
+  return ok(
+    {
+      id: templateId,
+      name: "Bronze to Silver ETL",
+      description: "Delta Lake bronze/silver pipeline with S3 source",
+      category: "pipeline",
+      config: {
+        layers: [
+          { name: "Bronze", resourceType: "pipeline", resourceId: "{{pipeline_id}}" },
+          { name: "Silver", resourceType: "pipeline", resourceId: "{{pipeline_id}}" },
+        ],
+        connections: ["s3-raw", "s3-curated"],
+        variables: [
+          { key: "catalog_name", required: true, default: "main" },
+          { key: "schema_prefix", required: false, default: "analytics" },
+        ],
+      },
+      resourceCount: 4,
+      popularity: 892,
+      createdAt: "2024-03-15T10:00:00Z",
+      updatedAt: "2024-06-01T09:00:00Z",
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/templates/route.ts
+++ b/app/api/v1/templates/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  parsePagePagination,
+  getRequestId,
+} from "@/lib/api/response";
+
+/**
+ * GET /api/v1/templates
+ * List available stack and pipeline templates for quick-start.
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const { page, pageSize } = parsePagePagination(searchParams, { pageSize: 25 });
+  const requestId = getRequestId(request);
+  const category = searchParams.get("category");
+
+  const templates = [
+    {
+      id: "tmpl-etl-bronze-silver",
+      name: "Bronze to Silver ETL",
+      description: "Delta Lake bronze/silver pipeline with S3 source",
+      category: "pipeline",
+      resourceCount: 4,
+      popularity: 892,
+      createdAt: "2024-03-15T10:00:00Z",
+    },
+    {
+      id: "tmpl-ml-feature-store",
+      name: "ML Feature Store",
+      description: "Feature store with offline/online tables",
+      category: "stack",
+      resourceCount: 6,
+      popularity: 445,
+      createdAt: "2024-04-01T14:00:00Z",
+    },
+    {
+      id: "tmpl-dbt-core",
+      name: "dbt Core Pipeline",
+      description: "dbt transformations with Delta tables",
+      category: "pipeline",
+      resourceCount: 3,
+      popularity: 1203,
+      createdAt: "2024-02-20T09:00:00Z",
+    },
+    {
+      id: "tmpl-realtime-kafka",
+      name: "Kafka Real-time Ingestion",
+      description: "Structured streaming from Kafka to Delta",
+      category: "stack",
+      resourceCount: 5,
+      popularity: 678,
+      createdAt: "2024-05-10T11:00:00Z",
+    },
+  ];
+
+  const filtered = category
+    ? templates.filter((t) => t.category === category)
+    : templates;
+  const totalCount = filtered.length;
+  const start = (page - 1) * pageSize;
+  const paged = filtered.slice(start, start + pageSize);
+
+  return listResponse("templates", paged, totalCount, {
+    page,
+    pageSize,
+    requestId,
+  });
+}

--- a/app/api/v1/usage/route.ts
+++ b/app/api/v1/usage/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest } from "next/server";
+import { ok, getRequestId } from "@/lib/api/response";
+
+/**
+ * GET /api/v1/usage
+ * Get workspace usage stats (compute, storage, API calls).
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const requestId = getRequestId(request);
+  const workspaceId = searchParams.get("workspaceId");
+  const period = searchParams.get("period") ?? "current_month";
+
+  return ok(
+    {
+      workspaceId: workspaceId ?? "ws-001",
+      period,
+      dbus: {
+        used: 245000,
+        limit: 500000,
+        unit: "DBU",
+      },
+      storage: {
+        usedGb: 1234,
+        limitGb: 5000,
+      },
+      apiCalls: {
+        used: 45230,
+        limit: 100000,
+      },
+      clusters: {
+        active: 3,
+        maxConcurrent: 10,
+        totalRuntimeHours: 156,
+      },
+      queries: {
+        executed: 12450,
+        avgLatencyMs: 234,
+      },
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/users/route.ts
+++ b/app/api/v1/users/route.ts
@@ -1,4 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  created,
+  parsePagePagination,
+  getRequestId,
+} from "@/lib/api/response";
 
 /**
  * @swagger
@@ -70,11 +76,13 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
-  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
-  const perPage = Math.min(100, Math.max(1, parseInt(searchParams.get("perPage") ?? "20", 10)));
+  const { page, pageSize } = parsePagePagination(searchParams, { pageSize: 20 });
+  const requestId = getRequestId(request);
+  const role = searchParams.get("role");
+  const teamId = searchParams.get("teamId");
+  const status = searchParams.get("status");
 
-  return NextResponse.json({
-    data: [
+  const users = [
       {
         id: "u1",
         displayName: "Ada Lovelace",
@@ -91,17 +99,25 @@ export async function GET(request: NextRequest) {
         permissions: ["clusters:write", "jobs:write", "pipelines:write", "admin:users"],
         externalId: null,
       },
-    ],
-    pagination: {
-      total: 1,
-      page,
-      perPage,
-      hasMore: false,
-    },
+    ];
+
+  let filtered = users;
+  if (role) filtered = filtered.filter((u) => u.role === role);
+  if (teamId) filtered = filtered.filter((u) => u.teamIds?.includes(teamId));
+  if (status) filtered = filtered.filter((u) => u.status === status);
+  const totalCount = filtered.length;
+  const start = (page - 1) * pageSize;
+  const paged = filtered.slice(start, start + pageSize);
+
+  return listResponse("users", paged, totalCount, {
+    page,
+    pageSize,
+    requestId,
   });
 }
 
 export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
   const body = (await request.json()) as {
     displayName: string;
     email: string;
@@ -113,7 +129,7 @@ export async function POST(request: NextRequest) {
     externalId?: string;
     metadata?: Record<string, string>;
   };
-  return NextResponse.json(
+  return created(
     {
       id: "u-new",
       displayName: body.displayName,
@@ -129,6 +145,6 @@ export async function POST(request: NextRequest) {
       externalId: body.externalId ?? null,
       metadata: body.metadata ?? {},
     },
-    { status: 201 }
+    { requestId }
   );
 }

--- a/app/api/v1/webhooks/route.ts
+++ b/app/api/v1/webhooks/route.ts
@@ -1,4 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import {
+  listResponse,
+  created,
+  parsePagePagination,
+  getRequestId,
+} from "@/lib/api/response";
 
 /**
  * @swagger
@@ -63,10 +69,12 @@ import { NextRequest, NextResponse } from "next/server";
  */
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
+  const { page, pageSize } = parsePagePagination(searchParams, { pageSize: 25 });
+  const requestId = getRequestId(request);
+  const activeParam = searchParams.get("active");
 
-  return NextResponse.json({
-    webhooks: [
-      {
+  const webhooks = [
+    {
         id: "wh-001",
         url: "https://hooks.acme.dev/datastack",
         events: ["job.completed", "job.failed", "pipeline.failed"],
@@ -85,12 +93,26 @@ export async function GET(request: NextRequest) {
           lastDeliveryStatus: "SUCCESS",
         },
       },
-    ],
-    totalCount: 1,
+    ];
+
+  let filtered = webhooks;
+  if (activeParam !== null && activeParam !== undefined) {
+    const active = activeParam === "true";
+    filtered = filtered.filter((w) => w.active === active);
+  }
+  const totalCount = filtered.length;
+  const start = (page - 1) * pageSize;
+  const paged = filtered.slice(start, start + pageSize);
+
+  return listResponse("webhooks", paged, totalCount, {
+    page,
+    pageSize,
+    requestId,
   });
 }
 
 export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
   const body = (await request.json()) as {
     url: string;
     events: string[];
@@ -101,7 +123,7 @@ export async function POST(request: NextRequest) {
     retryPolicy?: { maxRetries: number; retryIntervalSeconds: number; exponentialBackoff: boolean };
     contentType?: string;
   };
-  return NextResponse.json(
+  return created(
     {
       id: "wh-new",
       url: body.url,
@@ -121,6 +143,6 @@ export async function POST(request: NextRequest) {
         lastDeliveryStatus: null,
       },
     },
-    { status: 201 }
+    { requestId }
   );
 }

--- a/app/api/v1/workspaces/[workspaceId]/export/route.ts
+++ b/app/api/v1/workspaces/[workspaceId]/export/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from "next/server";
+import { ok, getRequestId } from "@/lib/api/response";
+
+/**
+ * GET /api/v1/workspaces/{workspaceId}/export
+ * Request or retrieve a workspace configuration export (stacks, jobs, connections metadata).
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ workspaceId: string }> }
+) {
+  const { workspaceId } = await params;
+  const searchParams = request.nextUrl.searchParams;
+  const requestId = getRequestId(request);
+  const format = searchParams.get("format") ?? "json";
+
+  return ok(
+    {
+      workspaceId,
+      format,
+      status: "ready",
+      exportedAt: new Date().toISOString(),
+      resources: {
+        stacks: 2,
+        jobs: 12,
+        pipelines: 5,
+        connections: 8,
+        queries: 24,
+      },
+      downloadUrl: `https://api.datastack.cloud/exports/${workspaceId}-${Date.now()}.${format}`,
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/workspaces/[workspaceId]/settings/route.ts
+++ b/app/api/v1/workspaces/[workspaceId]/settings/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from "next/server";
+import { ok, getRequestId } from "@/lib/api/response";
+
+/**
+ * GET /api/v1/workspaces/{workspaceId}/settings
+ * Get workspace-level settings (defaults, features, retention).
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ workspaceId: string }> }
+) {
+  const { workspaceId } = await params;
+  const requestId = getRequestId(request);
+
+  return ok(
+    {
+      workspaceId,
+      defaults: {
+        clusterAutoTerminationMinutes: 120,
+        jobRetryPolicy: { maxRetries: 3, retryIntervalSeconds: 300 },
+        pipelineEdition: "CORE",
+      },
+      features: {
+        photonEnabled: true,
+        deltaSharingEnabled: false,
+        mlflowTracking: true,
+      },
+      retention: {
+        jobRunLogsDays: 30,
+        queryHistoryDays: 90,
+        auditLogDays: 365,
+      },
+      security: {
+        ipAccessListEnabled: false,
+        requireMfaForApi: false,
+      },
+    },
+    { requestId }
+  );
+}
+
+/**
+ * PATCH /api/v1/workspaces/{workspaceId}/settings
+ * Update workspace-level settings.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ workspaceId: string }> }
+) {
+  const { workspaceId } = await params;
+  const requestId = getRequestId(request);
+  const body = (await request.json()) as Record<string, unknown>;
+
+  return ok(
+    {
+      workspaceId,
+      ...body,
+      updatedAt: new Date().toISOString(),
+    },
+    { requestId }
+  );
+}

--- a/app/api/v1/workspaces/route.ts
+++ b/app/api/v1/workspaces/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { listResponse, getRequestId } from "@/lib/api/response";
 
 /**
  * @swagger
@@ -17,9 +18,9 @@ import { NextRequest, NextResponse } from "next/server";
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get("pageSize") ?? "25", 10)));
+  const requestId = getRequestId(request);
 
-  return NextResponse.json({
-    workspaces: [
+  const workspaces = [
       {
         id: "ws-001",
         name: "Acme Corp Production",
@@ -36,8 +37,13 @@ export async function GET(request: NextRequest) {
         status: "ACTIVE",
         createdAt: "2024-02-01T12:00:00Z",
       },
-    ],
-    totalCount: 2,
-    nextPageToken: undefined,
+    ];
+
+  const totalCount = workspaces.length;
+  const paged = workspaces.slice(0, pageSize);
+
+  return listResponse("workspaces", paged, totalCount, {
+    pageSize,
+    requestId,
   });
 }

--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -1,0 +1,229 @@
+/**
+ * Modern DataStack API response utilities.
+ * Provides consistent response envelopes, pagination, and error handling
+ * per API Overview conventions.
+ */
+
+import { NextResponse } from "next/server";
+
+export const REQUEST_ID_HEADER = "x-request-id";
+export const RATE_LIMIT_REMAINING = "x-ratelimit-remaining";
+export const RATE_LIMIT_LIMIT = "x-ratelimit-limit";
+
+/** Standard error code for client/server issues */
+export type ApiErrorCode =
+  | "BAD_REQUEST"
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "RATE_LIMITED"
+  | "INTERNAL_ERROR";
+
+/** Pagination params for page-based endpoints (clusters, stacks, connections, etc.) */
+export interface PagePagination {
+  page: number;
+  pageSize: number;
+}
+
+/** Pagination params for offset-based endpoints (jobs, notebooks) */
+export interface OffsetPagination {
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Parse page-based pagination from URL search params.
+ * Supports both pageSize and perPage per API Overview.
+ */
+export function parsePagePagination(
+  searchParams: URLSearchParams,
+  defaults: { page?: number; pageSize?: number } = {}
+): PagePagination {
+  const page = Math.max(1, parseInt(searchParams.get("page") ?? String(defaults.page ?? 1), 10));
+  const pageSizeRaw =
+    searchParams.get("pageSize") ?? searchParams.get("perPage") ?? String(defaults.pageSize ?? 25);
+  const pageSize = Math.min(100, Math.max(1, parseInt(pageSizeRaw, 10)));
+  return { page, pageSize };
+}
+
+/**
+ * Parse offset-based pagination from URL search params.
+ */
+export function parseOffsetPagination(
+  searchParams: URLSearchParams,
+  defaults: { limit?: number; offset?: number } = {}
+): OffsetPagination {
+  const limit = Math.min(
+    100,
+    Math.max(1, parseInt(searchParams.get("limit") ?? String(defaults.limit ?? 25), 10))
+  );
+  const offset = Math.max(0, parseInt(searchParams.get("offset") ?? String(defaults.offset ?? 0), 10));
+  return { limit, offset };
+}
+
+/**
+ * Standard list envelope for page-based endpoints.
+ * Includes hasNextPage for cursor-less pagination UX.
+ */
+export interface ListEnvelope<T> {
+  page?: number;
+  pageSize?: number;
+  totalCount: number;
+  hasNextPage?: boolean;
+  nextPage?: number;
+  [key: string]: T[] | number | boolean | undefined;
+}
+
+/**
+ * Build list response with typed envelope.
+ * Resource key (e.g. "stacks", "clusters") must be the first additional property.
+ */
+export function listResponse<T>(
+  resourceKey: string,
+  items: T[],
+  totalCount: number,
+  options?: {
+    page?: number;
+    pageSize?: number;
+    limit?: number;
+    offset?: number;
+    requestId?: string;
+  }
+): NextResponse<ListEnvelope<T> & Record<string, unknown>> {
+  const envelope: ListEnvelope<T> & Record<string, unknown> = {
+    [resourceKey]: items,
+    totalCount,
+  };
+  if (options?.page !== undefined) envelope.page = options.page;
+  if (options?.pageSize !== undefined) envelope.pageSize = options.pageSize;
+  if (options?.limit !== undefined) envelope.limit = options.limit;
+  if (options?.offset !== undefined) envelope.offset = options.offset;
+  if (options?.page && options?.pageSize && totalCount > options.page * options.pageSize) {
+    envelope.hasNextPage = true;
+    envelope.nextPage = options.page + 1;
+  } else if (
+    options?.limit !== undefined &&
+    options?.offset !== undefined &&
+    totalCount > options.offset + items.length
+  ) {
+    envelope.hasMore = true;
+  }
+  const res = NextResponse.json(envelope);
+  if (options?.requestId) res.headers.set(REQUEST_ID_HEADER, options.requestId);
+  return res;
+}
+
+/**
+ * Standard error response shape for 4xx/5xx.
+ */
+export interface ApiErrorBody {
+  error: {
+    code: ApiErrorCode;
+    message: string;
+    details?: Record<string, unknown>;
+    requestId?: string;
+  };
+}
+
+function errorResponse(
+  status: number,
+  code: ApiErrorCode,
+  message: string,
+  options?: { details?: Record<string, unknown>; requestId?: string }
+): NextResponse<ApiErrorBody> {
+  const body: ApiErrorBody = {
+    error: {
+      code,
+      message,
+      ...(options?.details && { details: options.details }),
+      ...(options?.requestId && { requestId: options.requestId }),
+    },
+  };
+  const res = NextResponse.json(body, { status });
+  if (options?.requestId) res.headers.set(REQUEST_ID_HEADER, options.requestId);
+  return res;
+}
+
+export function badRequest(
+  message: string,
+  options?: { details?: Record<string, unknown>; requestId?: string }
+) {
+  return errorResponse(400, "BAD_REQUEST", message, options);
+}
+
+export function unauthorized(
+  message = "Authentication required",
+  options?: { requestId?: string }
+) {
+  return errorResponse(401, "UNAUTHORIZED", message, options);
+}
+
+export function forbidden(
+  message = "Insufficient permissions",
+  options?: { requestId?: string }
+) {
+  return errorResponse(403, "FORBIDDEN", message, options);
+}
+
+export function notFound(
+  resource: string,
+  id?: string,
+  options?: { requestId?: string }
+) {
+  const message = id ? `${resource} ${id} not found` : `${resource} not found`;
+  return errorResponse(404, "NOT_FOUND", message, options);
+}
+
+export function conflict(
+  message: string,
+  options?: { details?: Record<string, unknown>; requestId?: string }
+) {
+  return errorResponse(409, "CONFLICT", message, options);
+}
+
+export function rateLimited(
+  message = "Too many requests",
+  options?: { requestId?: string; retryAfter?: number }
+) {
+  const res = errorResponse(429, "RATE_LIMITED", message, options);
+  if (options?.retryAfter) res.headers.set("Retry-After", String(options.retryAfter));
+  return res;
+}
+
+export function internalError(
+  message = "An unexpected error occurred",
+  options?: { requestId?: string }
+) {
+  return errorResponse(500, "INTERNAL_ERROR", message, options);
+}
+
+/**
+ * Success responses with optional request ID header.
+ */
+export function ok<T>(data: T, options?: { requestId?: string }): NextResponse<T> {
+  const res = NextResponse.json(data);
+  if (options?.requestId) res.headers.set(REQUEST_ID_HEADER, options.requestId);
+  return res;
+}
+
+export function created<T>(data: T, options?: { requestId?: string }): NextResponse<T> {
+  const res = NextResponse.json(data, { status: 201 });
+  if (options?.requestId) res.headers.set(REQUEST_ID_HEADER, options.requestId);
+  return res;
+}
+
+export function noContent(options?: { requestId?: string }): NextResponse {
+  const res = new NextResponse(null, { status: 204 });
+  if (options?.requestId) res.headers.set(REQUEST_ID_HEADER, options.requestId);
+  return res;
+}
+
+/**
+ * Read X-Request-ID from request or generate a short id for tracing.
+ */
+export function getRequestId(request: Request): string {
+  const id = request.headers.get(REQUEST_ID_HEADER);
+  if (id) return id;
+  return `req_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 9)}`;
+}

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -12,6 +12,27 @@
     }
   ],
   "components": {
+    "schemas": {
+      "ApiError": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "message"],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": ["BAD_REQUEST", "UNAUTHORIZED", "FORBIDDEN", "NOT_FOUND", "CONFLICT", "RATE_LIMITED", "INTERNAL_ERROR"]
+              },
+              "message": { "type": "string" },
+              "details": { "type": "object" },
+              "requestId": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
     "securitySchemes": {
       "ApiKeyAuth": {
         "type": "apiKey",
@@ -28,6 +49,30 @@
   },
   "security": [],
   "paths": {
+    "/api/v1/health": {
+      "get": {
+        "summary": "Health check",
+        "description": "Liveness/readiness check. Returns 200 when the API is accepting requests.",
+        "responses": {
+          "200": {
+            "description": "API is healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": { "type": "string", "example": "ok" },
+                    "version": { "type": "string" },
+                    "timestamp": { "type": "string", "format": "date-time" },
+                    "requestId": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/auth/api-keys/{keyId}": {
       "delete": {
         "summary": "Revoke API key",
@@ -1817,10 +1862,71 @@
         }
       }
     },
+    "/api/v1/stacks/{stackId}/lock": {
+      "post": {
+        "summary": "Lock stack",
+        "description": "Acquire an exclusive lock on a stack to prevent concurrent modifications",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "stackId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": { "type": "string" },
+                  "ttlSeconds": { "type": "integer" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Success" },
+          "409": { "description": "Stack is already locked" }
+        }
+      }
+    },
+    "/api/v1/stacks/{stackId}/unlock": {
+      "post": {
+        "summary": "Unlock stack",
+        "description": "Release the lock on a stack",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "stackId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Success" },
+          "404": { "description": "Stack not found" }
+        }
+      }
+    },
     "/api/v1/stacks": {
       "get": {
         "summary": "List stacks",
-        "description": "List composable infrastructure stacks",
+        "description": "List composable infrastructure stacks with pagination",
+        "parameters": [
+          { "in": "query", "name": "page", "schema": { "type": "integer", "default": 1 } },
+          { "in": "query", "name": "pageSize", "schema": { "type": "integer", "default": 25 } },
+          { "in": "query", "name": "perPage", "schema": { "type": "integer" } },
+          { "in": "query", "name": "environment", "schema": { "type": "string", "enum": ["development", "staging", "production"] } },
+          { "in": "query", "name": "lockState", "schema": { "type": "string", "enum": ["LOCKED", "UNLOCKED"] } }
+        ],
         "responses": {
           "200": {
             "description": "Success"


### PR DESCRIPTION
- Add lib/api/response.ts (pagination, errors, request IDs)
- Add /api/v1/health, lock/unlock stacks in OpenAPI
- Update CRUD routes: consistent pagination, filters, X-Request-ID
- Add bulk ops: jobs/bulk-pause, bulk-resume, connections/bulk-test, stacks/bulk-validate
- Add templates: list, get, instantiate
- Add favorites: list, add, remove
- Add activity feed and me/recent
- Add me + me/preferences
- Add usage and limits
- Add pipeline/query clone
- Add workspace settings and export
- Add tags + suggest
- Add dashboards CRUD