### PR TITLE
chore: run docdrift on PRs to 6-month-api-modernization + concurrency

### DIFF
--- a/.github/workflows/docdrift.yml
+++ b/.github/workflows/docdrift.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "6-month-api-modernization"]
   workflow_dispatch:
+
+concurrency:
+  group: docdrift-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   docdrift:


### PR DESCRIPTION
- Add 6-month-api-modernization to pull_request branches
- Add concurrency group to cancel duplicate runs on same PR