### PR TITLE
Add analytics scopes/header and update docs

### DIFF
--- a/content/docs/getting-started/authentication.mdx
+++ b/content/docs/getting-started/authentication.mdx
@@ -82,3 +82,5 @@ Scopes control what a token or API key can access. Request only the scopes you n
 | `read:lineage` | View data lineage graphs |
 | `read:data_quality` | List data quality rules |
 | `manage:data_quality` | Create and manage data quality rules |
+| `read:analytics` | View analytics dashboards and reports |
+| `manage:analytics` | Create, update, and delete analytics configurations |

--- a/docdrift.yaml
+++ b/docdrift.yaml
@@ -29,7 +29,7 @@ pathMappings:
   - match: lib/api/preview.ts
     impacts:
       - ./content/docs/*
-mode: strict
+mode: auto
 branchStrategy: single
 devin:
   apiVersion: v1

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -35,6 +35,8 @@ export const SCOPES = {
   MANAGE_DEPLOYMENTS: "manage:deployments",
   MANAGE_WEBHOOKS: "manage:webhooks",
   MANAGE_API_KEYS: "manage:api_keys",
+  READ_ANALYTICS: "read:analytics",
+  MANAGE_ANALYTICS: "manage:analytics",
 } as const;
 
 export type Scope = (typeof SCOPES)[keyof typeof SCOPES];

--- a/lib/api/preview.ts
+++ b/lib/api/preview.ts
@@ -12,6 +12,7 @@ export const FEATURE_STREAMING_HEADER = "x-datastack-feature-streaming";
 export const FEATURE_MLOPS_HEADER = "x-datastack-feature-mlops";
 export const FEATURE_ALERTS_HEADER = "x-datastack-feature-alerts";
 export const FEATURE_CATALOG_HEADER = "x-datastack-feature-catalog";
+export const FEATURE_ANALYTICS_HEADER = "x-datastack-feature-analytics";
 
 export function isPreviewEnabled(request: NextRequest): boolean {
   return request.headers.get(PREVIEW_HEADER) === "true";


### PR DESCRIPTION
## Summary

Conceptual/non-route changes for docdrift testing:
- `lib/api/auth.ts`: add `READ_ANALYTICS` and `MANAGE_ANALYTICS` scopes
- `lib/api/preview.ts`: add `FEATURE_ANALYTICS_HEADER`
- `docdrift.yaml`: set mode to `auto` (from `strict`)

### Updates since last revision

- `content/docs/getting-started/authentication.mdx`: added `read:analytics` and `manage:analytics` to the scopes documentation table to reflect the new scopes in code
- `openapi/openapi.json` was verified identical to `openapi/generated.json` — no spec drift to fix
- `npm run build` passes cleanly

## Review & Testing Checklist for Human

- [ ] Verify the scope descriptions for `read:analytics` ("View analytics dashboards and reports") and `manage:analytics` ("Create, update, and delete analytics configurations") match the intended functionality — these were inferred from naming conventions since no analytics API routes exist yet
- [ ] Confirm no other doc pages need to reference the new `x-datastack-feature-analytics` preview header (currently no feature-flag docs exist in the docsite)

### Notes

- No changes to `openapi/openapi.json`, `content/docs/faq/**`, or `content/docs/api-reference/overview.mdx`
- Made with [Cursor](https://cursor.com)
- Link to Devin run: https://app.devin.ai/sessions/1f7e174a0f6a4648924f56c54426fa76
- Requested by: @cameronking4